### PR TITLE
Made restoring of application window more robust

### DIFF
--- a/SPDIFKA/SPDIFGUI.cs
+++ b/SPDIFKA/SPDIFGUI.cs
@@ -125,7 +125,7 @@ namespace SPDIFKA
         {
             this.isAppVisible = false;
             spdifka.Visible = true;
-            this.ShowInTaskbar = false;            
+            this.ShowInTaskbar = false;
             this.Hide();
         }
 
@@ -137,7 +137,8 @@ namespace SPDIFKA
             this.isAppVisible = true;
             this.WindowState = FormWindowState.Normal;
             this.ShowInTaskbar = true;
-            this.Show();           
+            this.Show();
+            this.Activate();
         }
 
         /// <summary>
@@ -228,7 +229,7 @@ namespace SPDIFKA
         /// </summary>
         /// <param name="isRunning"></param>
         private void updateTrayIconWhenRunning(Boolean isRunning)
-        {            
+        {
             if (isRunning)
             {
                 spdifka.Icon = Properties.Resources.bar_chart_64_green;


### PR DESCRIPTION
When the application window is restored by left clicking on the notification area icon, it will now reliably be given focus and brought to the foreground. Likewise, when the application window is already open, if the user left clicks the notification area icon the application window will get focus and be brought to the foreground.