### PR TITLE
Prevent multiple instances

### DIFF
--- a/SPDIFKA/SPDIFKA.cs
+++ b/SPDIFKA/SPDIFKA.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace SPDIFKA
@@ -14,9 +12,22 @@ namespace SPDIFKA
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new SPDIFKAGUI());
+            using (Mutex mutex = new Mutex(false, @"Global\" + "spdif-ka_mutex"))
+            {
+                try
+                {
+                    if (mutex.WaitOne(0, false)) // This is the only instance
+                    {
+                        Application.EnableVisualStyles();
+                        Application.SetCompatibleTextRenderingDefault(false);
+                        Application.Run(new SPDIFKAGUI());
+                    }
+                }
+                finally
+                {
+                    mutex.Close();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Prevent multiple competing instances by having the application check whether it is the only instance when it is run.