### PR TITLE
Allow DoubleClick on notification icon

### DIFF
--- a/SPDIFKA/SPDIFGUI.Designer.cs
+++ b/SPDIFKA/SPDIFGUI.Designer.cs
@@ -32,14 +32,14 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SPDIFKAGUI));
             this.startStopButton = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
-            this.spdifka = new System.Windows.Forms.NotifyIcon(this.components);
+            this.NotifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.runningLabel = new System.Windows.Forms.Label();
             this.RightClickMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripStart = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripExit = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripAbout = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripExit = new System.Windows.Forms.ToolStripMenuItem();
             this.TabsMenu1 = new System.Windows.Forms.TabControl();
             this.MainPage = new System.Windows.Forms.TabPage();
             this.TabSettings = new System.Windows.Forms.TabPage();
@@ -51,6 +51,7 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.inaudible_sound = new System.Windows.Forms.RadioButton();
             this.silent_sound = new System.Windows.Forms.RadioButton();
+            this.DoubleClickTimer = new System.Windows.Forms.Timer(this.components);
             this.RightClickMenuStrip.SuspendLayout();
             this.TabsMenu1.SuspendLayout();
             this.MainPage.SuspendLayout();
@@ -78,11 +79,12 @@
             this.label1.TabIndex = 1;
             this.label1.Text = "SPDIF Keep Alive:";
             // 
-            // spdifka
+            // NotifyIcon
             // 
-            this.spdifka.Text = "SPDIF-KA";
-            this.spdifka.Visible = true;
-            this.spdifka.MouseClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon_MouseClick);
+            this.NotifyIcon.Text = "SPDIF-KA";
+            this.NotifyIcon.Visible = true;
+            this.NotifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.NotifyIcon_MouseClick);
+            this.NotifyIcon.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.NotifyIcon_MouseDoubleClick);
             // 
             // runningLabel
             // 
@@ -103,38 +105,38 @@
             this.toolStripSeparator2,
             this.toolStripExit});
             this.RightClickMenuStrip.Name = "contextMenuStrip1";
-            this.RightClickMenuStrip.Size = new System.Drawing.Size(153, 104);
+            this.RightClickMenuStrip.Size = new System.Drawing.Size(111, 82);
             // 
             // toolStripStart
             // 
             this.toolStripStart.Name = "toolStripStart";
-            this.toolStripStart.Size = new System.Drawing.Size(152, 22);
+            this.toolStripStart.Size = new System.Drawing.Size(110, 22);
             this.toolStripStart.Text = "[temp]";
             this.toolStripStart.Click += new System.EventHandler(this.toolStripStart_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(149, 6);
-            // 
-            // toolStripExit
-            // 
-            this.toolStripExit.Name = "toolStripExit";
-            this.toolStripExit.Size = new System.Drawing.Size(152, 22);
-            this.toolStripExit.Text = "Exit";
-            this.toolStripExit.Click += new System.EventHandler(this.toolStripExit_Click);
-            // 
-            // toolStripSeparator2
-            // 
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(149, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(107, 6);
             // 
             // toolStripAbout
             // 
             this.toolStripAbout.Name = "toolStripAbout";
-            this.toolStripAbout.Size = new System.Drawing.Size(152, 22);
+            this.toolStripAbout.Size = new System.Drawing.Size(110, 22);
             this.toolStripAbout.Text = "About";
             this.toolStripAbout.Click += new System.EventHandler(this.toolStripAbout_Click);
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(107, 6);
+            // 
+            // toolStripExit
+            // 
+            this.toolStripExit.Name = "toolStripExit";
+            this.toolStripExit.Size = new System.Drawing.Size(110, 22);
+            this.toolStripExit.Text = "Exit";
+            this.toolStripExit.Click += new System.EventHandler(this.toolStripExit_Click);
             // 
             // TabsMenu1
             // 
@@ -266,6 +268,10 @@
             this.silent_sound.UseVisualStyleBackColor = true;
             this.silent_sound.CheckedChanged += new System.EventHandler(this.silent_sound_CheckedChanged);
             // 
+            // DoubleClickTimer
+            // 
+            this.DoubleClickTimer.Tick += new System.EventHandler(this.DoubleClickTimer_Tick);
+            // 
             // SPDIFKAGUI
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -294,7 +300,7 @@
 
         private System.Windows.Forms.Button startStopButton;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.NotifyIcon spdifka;
+        private System.Windows.Forms.NotifyIcon NotifyIcon;
         private System.Windows.Forms.Label runningLabel;
         private System.Windows.Forms.ContextMenuStrip RightClickMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem toolStripStart;
@@ -313,6 +319,7 @@
         private System.Windows.Forms.RadioButton silent_sound;
         private System.Windows.Forms.CheckBox IsMinimizeOnCloseCheckbox;
         private System.Windows.Forms.CheckBox IsMinimizeToNotificationCheckbox;
+        private System.Windows.Forms.Timer DoubleClickTimer;
     }
 }
 

--- a/SPDIFKA/SPDIFGUI.cs
+++ b/SPDIFKA/SPDIFGUI.cs
@@ -29,14 +29,14 @@ namespace SPDIFKA
             this.Icon = Properties.Resources.bar_chart_64_red;
             this.MaximizeBox = false;
 
-            this.spdifka.BalloonTipIcon = System.Windows.Forms.ToolTipIcon.Info;
-            this.spdifka.BalloonTipText = name + " - " + stoppedMessage;
-            this.spdifka.BalloonTipTitle = name;
-            this.spdifka.Text = name + " - " + stoppedMessage;
-            this.spdifka.Icon = Properties.Resources.bar_chart_64_red;
+            this.NotifyIcon.BalloonTipIcon = System.Windows.Forms.ToolTipIcon.Info;
+            this.NotifyIcon.BalloonTipText = name + " - " + stoppedMessage;
+            this.NotifyIcon.BalloonTipTitle = name;
+            this.NotifyIcon.Text = name + " - " + stoppedMessage;
+            this.NotifyIcon.Icon = Properties.Resources.bar_chart_64_red;
 
             toolStripStart.Text = toolStripStartText;
-            this.spdifka.ContextMenuStrip = RightClickMenuStrip;
+            this.NotifyIcon.ContextMenuStrip = RightClickMenuStrip;
             this.Resize += new System.EventHandler(this.Form1_Resize);
             runningLabel.Text = stoppedMessage;
             FormBorderStyle = FormBorderStyle.FixedSingle;
@@ -128,7 +128,7 @@ namespace SPDIFKA
         private void minimize()
         {
             
-            spdifka.Visible = true;
+            NotifyIcon.Visible = true;
             this.minimized_to_notificaton_area();
             
         }
@@ -166,10 +166,26 @@ namespace SPDIFKA
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void notifyIcon_MouseClick(object sender, MouseEventArgs e)
+        private void NotifyIcon_MouseClick(object sender, MouseEventArgs e)
         {
             if (e.Button.Equals(MouseButtons.Left))
             {
+                DoubleClickTimer.Interval = (int)(SystemInformation.DoubleClickTime);
+                DoubleClickTimer.Start(); // wait to ensure the user has not started a double click
+            }
+        }
+
+        private void DoubleClickTimer_Tick(object sender, EventArgs e)
+        {
+            DoubleClickTimer.Stop();
+            this.restore();
+        }
+
+        private void NotifyIcon_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button.Equals(MouseButtons.Left))
+            {
+                DoubleClickTimer.Stop();
                 this.restore();
             }
         }
@@ -213,7 +229,7 @@ namespace SPDIFKA
         private void exit_application()
         {
             AudioControl.Instance.stop();  //Ensure audio stops before exiting.
-            spdifka.Icon = null;  //Ensure tray icon does not persist after close.
+            NotifyIcon.Icon = null;  //Ensure tray icon does not persist after close.
             Application.Exit();
         }
 
@@ -234,21 +250,21 @@ namespace SPDIFKA
         {
             if (!AudioControl.Instance.isRunning())
             {
-                this.spdifka.Text = name + " - " + startMessage;
+                this.NotifyIcon.Text = name + " - " + startMessage;
                 toolStripStart.Text = toolStripStopText;
                 runningLabel.Text = startMessage;
-                this.spdifka.BalloonTipText = name + " - " + startMessage;
+                this.NotifyIcon.BalloonTipText = name + " - " + startMessage;
                 startStopButton.Text = "Stop";
                 AudioControl.Instance.start();
                 this.updateTrayIconWhenRunning(true);
             }
             else
             {
-                this.spdifka.Text = name + " - " + stoppedMessage;
+                this.NotifyIcon.Text = name + " - " + stoppedMessage;
                 startStopButton.Text = "Start";
                 toolStripStart.Text = toolStripStartText;
                 runningLabel.Text = stoppedMessage;
-                this.spdifka.BalloonTipText = name + " - " + stoppedMessage;
+                this.NotifyIcon.BalloonTipText = name + " - " + stoppedMessage;
                 AudioControl.Instance.stop();
                 this.updateTrayIconWhenRunning(false);
             }
@@ -274,12 +290,12 @@ namespace SPDIFKA
         {
             if (isRunning)
             {
-                spdifka.Icon = Properties.Resources.bar_chart_64_green;
+                NotifyIcon.Icon = Properties.Resources.bar_chart_64_green;
                 this.Icon = Properties.Resources.bar_chart_64_green;
             }
             else
             {
-                spdifka.Icon = Properties.Resources.bar_chart_64_red;
+                NotifyIcon.Icon = Properties.Resources.bar_chart_64_red;
                 this.Icon = Properties.Resources.bar_chart_64_red;
             }
         }

--- a/SPDIFKA/SPDIFGUI.resx
+++ b/SPDIFKA/SPDIFGUI.resx
@@ -117,11 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="spdifka.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="NotifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="RightClickMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>123, 17</value>
+    <value>125, 17</value>
+  </metadata>
+  <metadata name="DoubleClickTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>288, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
Ensure that the user can either single click or double click on the notification icon to restore the form. A timer is used to prevent an attempted double click from being interpreted as a series of single clicks, thus ensuring that the restored form always gets focus correctly.